### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,4 +1,6 @@
 name: C/C++ CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/chrisdebian/wsjt-x-improved/security/code-scanning/1](https://github.com/chrisdebian/wsjt-x-improved/security/code-scanning/1)

The best way to fix this problem is to add a `permissions` key to the workflow file. You can place this at the top level (applies to all jobs) or at the job level (applies just to that job). For most CI workflows, `contents: read` is sufficient, unless the workflow needs additional write permissions for actions like creating releases, commenting on issues, etc. In this workflow, the steps shown are limited to building and testing code, so setting `permissions: contents: read` at the root level is sufficient. To implement the change, add the following block right after the workflow `name` and before `on:` or at job level if more granularity is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
